### PR TITLE
Fix when file size is multiple of num blocks

### DIFF
--- a/frodo.c
+++ b/frodo.c
@@ -57,8 +57,10 @@ int pop_request() {
 int push_read_request(int file_fd, off_t file_sz) {
     // aiming for 8 blocks. (https://www.oreilly.com/library/view/linux-system-programming/9781449341527/ch04.html)
     int total_blocks = INITIAL_NUM_BLOCKS;
-    off_t last_block_size = 0;
-    off_t initial_block_size = file_sz / total_blocks;
+    off_t last_block_size;
+    off_t initial_block_size;
+
+    last_block_size = initial_block_size = file_sz / total_blocks;
 
     if (initial_block_size == 0) {
         total_blocks = 0;

--- a/frodo_test.go
+++ b/frodo_test.go
@@ -61,6 +61,10 @@ func TestRead(t *testing.T) {
 	t.Run("LargeFile", func(t *testing.T) {
 		helper("testdata/coverage.out")
 	})
+
+	t.Run("MultipleOf7", func(t *testing.T) {
+		helper("testdata/shire.txt")
+	})
 }
 
 func TestQueueThreshold(t *testing.T) {

--- a/testdata/shire.txt
+++ b/testdata/shire.txt
@@ -1,0 +1,1 @@
+Hello from io_uring, frodo!


### PR DESCRIPTION
last_block_size was incorrectly left at 0, when it should have been
equal to initial_block_size.